### PR TITLE
bau: Improve the descriptions of the tests

### DIFF
--- a/src/main/java/uk/gov/ida/verifymatchingservicetesttool/scenarios/DynamicScenarios.java
+++ b/src/main/java/uk/gov/ida/verifymatchingservicetesttool/scenarios/DynamicScenarios.java
@@ -7,13 +7,8 @@ import org.junit.jupiter.api.function.Executable;
 import uk.gov.ida.verifymatchingservicetesttool.configurations.ApplicationConfiguration;
 import uk.gov.ida.verifymatchingservicetesttool.resolvers.ApplicationConfigurationResolver;
 import uk.gov.ida.verifymatchingservicetesttool.utils.DynamicScenariosFilesLocator;
-import uk.gov.ida.verifymatchingservicetesttool.utils.FileUtils;
 
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.File;
 import java.util.HashSet;

--- a/src/main/java/uk/gov/ida/verifymatchingservicetesttool/scenarios/LevelOfAssuranceOneScenario.java
+++ b/src/main/java/uk/gov/ida/verifymatchingservicetesttool/scenarios/LevelOfAssuranceOneScenario.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.verifymatchingservicetesttool.scenarios;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import uk.gov.ida.verifymatchingservicetesttool.configurations.ApplicationConfiguration;
@@ -11,9 +12,6 @@ import java.time.Instant;
 
 import static java.time.temporal.ChronoUnit.DAYS;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.AnyOf.anyOf;
-import static org.hamcrest.core.Is.is;
 
 @ExtendWith(ApplicationConfigurationResolver.class)
 public class LevelOfAssuranceOneScenario extends ScenarioBase {
@@ -23,6 +21,7 @@ public class LevelOfAssuranceOneScenario extends ScenarioBase {
     }
 
     @Test
+    @DisplayName("Simple request with level of assurance 1")
     public void runForSimpleCase() {
         Response response = client.target(configuration.getLocalMatchingServiceMatchUrl())
             .request(APPLICATION_JSON)
@@ -32,7 +31,8 @@ public class LevelOfAssuranceOneScenario extends ScenarioBase {
     }
 
     @Test
-    public void runForExtensiveCase() {
+    @DisplayName("Complex request with level of assurance 1")
+    public void runForComplexCase() {
         String jsonString = fileUtils.readFromResources("LoA1-extensive-case.json")
             .replace("%yesterdayDate%", Instant.now().minus(1, DAYS).toString())
             .replace("%within405days-100days%", Instant.now().minus(405-100, DAYS).toString())

--- a/src/main/java/uk/gov/ida/verifymatchingservicetesttool/scenarios/LevelOfAssuranceTwoScenario.java
+++ b/src/main/java/uk/gov/ida/verifymatchingservicetesttool/scenarios/LevelOfAssuranceTwoScenario.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.verifymatchingservicetesttool.scenarios;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import uk.gov.ida.verifymatchingservicetesttool.configurations.ApplicationConfiguration;
@@ -11,9 +12,6 @@ import java.time.Instant;
 
 import static java.time.temporal.ChronoUnit.DAYS;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.AnyOf.anyOf;
-import static org.hamcrest.core.Is.is;
 
 @ExtendWith(ApplicationConfigurationResolver.class)
 public class LevelOfAssuranceTwoScenario extends ScenarioBase {
@@ -23,6 +21,7 @@ public class LevelOfAssuranceTwoScenario extends ScenarioBase {
     }
 
     @Test
+    @DisplayName("Simple request with level of assurance 2")
     public void runForWhenAllElementsAreVerifiedAndNoMultipleValues() {
         Response response = client.target(configuration.getLocalMatchingServiceMatchUrl())
             .request(APPLICATION_JSON)
@@ -32,7 +31,8 @@ public class LevelOfAssuranceTwoScenario extends ScenarioBase {
     }
 
     @Test
-    public void runForExtensiveCase() {
+    @DisplayName("Complex request with level of assurance 2")
+    public void runForComplexCase() {
         String jsonString = fileUtils.readFromResources("LoA2-extensive-case.json")
             .replace("%yesterdayDate%", Instant.now().minus(1, DAYS).toString())
             .replace("%within405days-100days%", Instant.now().minus(405-100, DAYS).toString())

--- a/src/main/java/uk/gov/ida/verifymatchingservicetesttool/scenarios/OptionalAddressFieldsExcludedScenario.java
+++ b/src/main/java/uk/gov/ida/verifymatchingservicetesttool/scenarios/OptionalAddressFieldsExcludedScenario.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.verifymatchingservicetesttool.scenarios;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import uk.gov.ida.verifymatchingservicetesttool.configurations.ApplicationConfiguration;
@@ -9,9 +10,6 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.AnyOf.anyOf;
-import static org.hamcrest.core.Is.is;
 
 @ExtendWith(ApplicationConfigurationResolver.class)
 public class OptionalAddressFieldsExcludedScenario extends ScenarioBase {
@@ -21,6 +19,7 @@ public class OptionalAddressFieldsExcludedScenario extends ScenarioBase {
     }
 
     @Test
+    @DisplayName("Simple request with address missing optional fields")
     public void runCase() {
         Response response = client.target(configuration.getLocalMatchingServiceMatchUrl())
             .request(APPLICATION_JSON)

--- a/src/main/java/uk/gov/ida/verifymatchingservicetesttool/scenarios/UserAccountCreationScenario.java
+++ b/src/main/java/uk/gov/ida/verifymatchingservicetesttool/scenarios/UserAccountCreationScenario.java
@@ -1,22 +1,15 @@
 package uk.gov.ida.verifymatchingservicetesttool.scenarios;
 
-import org.hamcrest.core.Is;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import uk.gov.ida.verifymatchingservicetesttool.configurations.ApplicationConfiguration;
 import uk.gov.ida.verifymatchingservicetesttool.resolvers.ApplicationConfigurationResolver;
 
 import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
-import java.util.HashSet;
-import java.util.Map;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static javax.ws.rs.core.Response.Status.OK;
-import static org.hamcrest.CoreMatchers.anyOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @ExtendWith(ApplicationConfigurationResolver.class)
@@ -27,6 +20,11 @@ public class UserAccountCreationScenario extends ScenarioBase {
     }
 
     @Test
+    @DisplayName(
+        "Simple user account creation request\n" +
+        "(remove accountCreationUrl from verify-matching-service-test-tool.yml " +
+        "to skip this if you don't need to test account creation)"
+    )
     public void runForUserAccountCreation() {
         assumeTrue(
             configuration.getLocalMatchingServiceAccountCreationUrl() != null,


### PR DESCRIPTION
This changes the output from:

```
Running test : example-match.json
Status : FAILED
javax.ws.rs.ProcessingException: java.net.ConnectException: Connection refused (Connection refused)

Running test : example-no-match.json
Status : FAILED
javax.ws.rs.ProcessingException: java.net.ConnectException: Connection refused (Connection refused)

Running test : runForSimpleCase()
Status : FAILED
javax.ws.rs.ProcessingException: java.net.ConnectException: Connection refused (Connection refused)

Running test : runForExtensiveCase()
Status : FAILED
javax.ws.rs.ProcessingException: java.net.ConnectException: Connection refused (Connection refused)

Running test : runForWhenAllElementsAreVerifiedAndNoMultipleValues()
Status : FAILED
javax.ws.rs.ProcessingException: java.net.ConnectException: Connection refused (Connection refused)

Running test : runForExtensiveCase()
Status : FAILED
javax.ws.rs.ProcessingException: java.net.ConnectException: Connection refused (Connection refused)

Running test : runCase()
Status : FAILED
javax.ws.rs.ProcessingException: java.net.ConnectException: Connection refused (Connection refused)

Running test : runForUserAccountCreation()
Status : FAILED
javax.ws.rs.ProcessingException: java.net.ConnectException: Connection refused (Connection refused)
```

To:

```
Running test : example-match.json
Status : FAILED
javax.ws.rs.ProcessingException: java.net.ConnectException: Connection refused (Connection refused)

Running test : example-no-match.json
Status : FAILED
javax.ws.rs.ProcessingException: java.net.ConnectException: Connection refused (Connection refused)

Running test : Simple request with level of assurance 1
Status : FAILED
javax.ws.rs.ProcessingException: java.net.ConnectException: Connection refused (Connection refused)

Running test : Complex request with level of assurance 1
Status : FAILED
javax.ws.rs.ProcessingException: java.net.ConnectException: Connection refused (Connection refused)

Running test : Simple request with level of assurance 2
Status : FAILED
javax.ws.rs.ProcessingException: java.net.ConnectException: Connection refused (Connection refused)

Running test : Complex request with level of assurance 2
Status : FAILED
javax.ws.rs.ProcessingException: java.net.ConnectException: Connection refused (Connection refused)

Running test : Simple request with address missing optional fields
Status : FAILED
javax.ws.rs.ProcessingException: java.net.ConnectException: Connection refused (Connection refused)

Running test : Simple user account creation request
(remove accountCreationUrl from verify-matching-service-test-tool.yml to skip this if you don't need to test account creation)
Status : FAILED
javax.ws.rs.ProcessingException: java.net.ConnectException: Connection refused (Connection refused)

Test execution finished. Number of all tests: 8
```

Authors: @richardtowers